### PR TITLE
Add Maven Central publishing workflow and update project metadata

### DIFF
--- a/.github/workflows/maven-central-publish.yml
+++ b/.github/workflows/maven-central-publish.yml
@@ -1,0 +1,32 @@
+name: Publish to Maven Central
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          cache: 'gradle'
+
+      - name: Import GPG key
+        run: |
+          echo "$GPG_PRIVATE_KEY" | gpg --batch --import
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+
+      - name: Publish to Maven Central
+        run: ./gradlew publish --no-daemon
+        env:
+          OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'maven-publish'
     id 'org.springframework.boot' version '3.1.5'
     id 'io.spring.dependency-management' version '1.1.3'
+    id 'signing'
 }
 
 group = 'io.github.eduardnol'
@@ -85,6 +86,16 @@ publishing {
                         email = 'dev@github'
                     }
                 }
+
+                scm {
+                    connection = 'scm:git:git://github.com/eduardnol/direccions-lib.git'
+                    developerConnection = 'scm:git:ssh://github.com:eduardnol/direccions-lib.git'
+                    url = 'https://github.com/eduardnol/direccions-lib'
+                }
+                organization {
+                    name = 'Eduardo Nolla'
+                    url = 'https://github.com/eduardnol'
+                }
             }
         }
     }
@@ -98,9 +109,22 @@ publishing {
                 password = project.findProperty("gpr.key") ?: System.getenv("TOKEN")
             }
         }
+        maven {
+            name = "MavenCentral"
+            url = uri("https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/")
+            credentials {
+                username = project.findProperty("ossrhUsername") ?: System.getenv("OSSRH_USERNAME")
+                password = project.findProperty("ossrhPassword") ?: System.getenv("OSSRH_PASSWORD")
+            }
+        }
         /*
         maven {
             name = "privateRepo"
+            // Firma de artefactos para Maven Central
+            signing {
+                required { gradle.taskGraph.hasTask("publish") }
+                sign publishing.publications.maven
+            }
             url = uri("https://your-private-repo.com/repository/maven-public/")
             credentials {
                 username = project.findProperty("repo.user") ?: System.getenv("REPO_USER")

--- a/src/main/resources/META-INF/LICENSE
+++ b/src/main/resources/META-INF/LICENSE
@@ -1,0 +1,19 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+Copyright 2025 Eduardo Nolla
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/src/main/resources/META-INF/MANIFEST.MF
+++ b/src/main/resources/META-INF/MANIFEST.MF
@@ -1,0 +1,5 @@
+Manifest-Version: 1.0
+Implementation-Title: Direccions Library
+Implementation-Version: 0.0.9
+Implementation-Vendor: Eduardo Nolla
+Implementation-URL: https://github.com/eduardnol/direccions-lib

--- a/src/main/resources/META-INF/NOTICE
+++ b/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,4 @@
+Direccions Library
+Copyright 2025 Eduardo Nolla
+
+This product includes software developed by Eduardo Nolla.


### PR DESCRIPTION
- Create GitHub Actions workflow for publishing to Maven Central
- Add signing plugin to build.gradle for artifact signing
- Include SCM and organization information in publishing configuration
- Add LICENSE, MANIFEST.MF, and NOTICE files for project compliance