### PR TITLE
Update Gradle wrapper to version 8.14 and clean up build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,6 @@ bootJar {
 // Configure Vanniktech Maven Publish Plugin for Maven Central
 mavenPublishing {
     publishToMavenCentral()
-    
     signAllPublications()
     
     coordinates(group.toString(), 'direccions-lib', version.toString())

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
- Updated the Gradle wrapper distribution URL to use version 8.14
- Removed unnecessary blank line in build.gradle for cleaner configuration