### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/maven-central-publish.yml
+++ b/.github/workflows/maven-central-publish.yml
@@ -5,6 +5,8 @@ on:
 
 jobs:
   publish:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/Eduardnol/direccions-lib/security/code-scanning/1](https://github.com/Eduardnol/direccions-lib/security/code-scanning/1)

To address the error, you should add an explicit `permissions` block to the workflow or to the relevant job, restricting access to only those actions and scopes required. In this workflow, the job checks out code and performs a publish to Maven Central (using secrets for authentication). Unless you have steps that write to issues, repository contents, or pull requests, you can safely set `permissions: contents: read` at the job level. This limits the GITHUB_TOKEN privileges while still enabling code checkout. Insert this block directly under the job name at line 8 (after `publish:` and before `runs-on:`). No additional imports or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
